### PR TITLE
Fix the OR logic for the long argument with MerMod objects

### DIFF
--- a/R/mediate.R
+++ b/R/mediate.R
@@ -1476,7 +1476,7 @@ mediate <- function(model.m, model.y, sims = 1000,
                   robustSE = robustSE, cluster = cluster)
       class(out) <- "mediate"
     }
-    if(long && isMer.y || isMer.m) {
+    if(long && isMer.y ||long && isMer.m) {
       out <- list(d0=d0, d1=d1, d0.ci=d0.ci, d1.ci=d1.ci,
                   d0.p=d0.p, d1.p=d1.p,
                   d0.sims=delta.0, d1.sims=delta.1,
@@ -1517,7 +1517,7 @@ mediate <- function(model.m, model.y, sims = 1000,
                   robustSE = robustSE, cluster = cluster)  
       class(out) <- "mediate.mer"
     }
-    if(!long && isMer.y || isMer.m){
+    if(!long && isMer.y ||!long && isMer.m){
       out <- list(d0=d0, d1=d1, d0.ci=d0.ci, d1.ci=d1.ci,
                   d0.p=d0.p, d1.p=d1.p,
                   z0=z0, z1=z1, z0.ci=z0.ci, z1.ci=z1.ci,


### PR DESCRIPTION
Previously the final test was checking if (not long && isMer.y OR isMer.x) - which always triggered the not long case when a MerMod object was present for model x. Thus, you could never get long output from a mediation with a MerMod x model. Now, it tests if (not long && isMer.y OR not long && isMer.x). The updated code gave the correct output in my test case.
